### PR TITLE
Fix wrong ECC type on rb91x_nand

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -309,8 +309,7 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 	drvdata->chip.legacy.read_buf = rb91x_nand_read_buf;
 
 	drvdata->chip.legacy.chip_delay = 25;
-	drvdata->chip.ecc.engine_type      = NAND_ECC_ENGINE_TYPE_SOFT;
-	drvdata->chip.ecc.algo             = NAND_ECC_ALGO_HAMMING;
+	drvdata->chip.ecc.engine_type      = NAND_ECC_ENGINE_TYPE_ON_DIE;
 	drvdata->chip.options = NAND_NO_SUBPAGE_WRITE;
 
 	r = nand_scan(&drvdata->chip, 1);


### PR DESCRIPTION
These boards ships with TC58BVG0S3HTA00 nand flash that, accordingly to datasheet has ECC logic on chip.
Setting software ECC can lead to redundancy and performace loss as well as warnings in kernel messages about ecc algorithm weaknesses.

